### PR TITLE
support MySQL 5.7.6 or later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: go
 go:
-    - 1.1
-    - 1.2
+    - tip

--- a/README.md
+++ b/README.md
@@ -49,8 +49,3 @@ config.Port = 13306
 // Starts mysqld listening on port 13306
 mysqld, _ := mysqltest.NewMysqld(config)
 ```
-
-TODO
-====
-
-* CopyDataFrom is not implemented.

--- a/mysqltest.go
+++ b/mysqltest.go
@@ -280,8 +280,7 @@ func (m *TestMysqld) Setup() error {
 				mysqlBaseDir = config.MysqlInstallDb
 			}
 
-			filepath.Dir(filepath.Dir(mysqlBaseDir))
-			setupArgs = append(setupArgs, fmt.Sprintf("--basedir=%s", filepath.Dir(mysqlBaseDir)))
+			setupArgs = append(setupArgs, fmt.Sprintf("--basedir=%s", filepath.Dir(filepath.Dir(mysqlBaseDir))))
 		} else {
 			setupCmd = config.Mysqld
 			setupArgs = append(setupArgs, "--initialize-insecure")


### PR DESCRIPTION
`mysql_install_db` is obsoleted at MySQL 5.7.6 or later and should use `mysqld --initialize-insecure` instead.