### PR TITLE
Topic/pr 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ before_script:
 go:
     - 1.7
     - tip
+script:
+    - go test -v -race ./...

--- a/mysqltest_test.go
+++ b/mysqltest_test.go
@@ -13,6 +13,7 @@ func TestBasic(t *testing.T) {
 	mysqld, err := NewMysqld(NewConfig())
 	if err != nil {
 		t.Errorf("Failed to start mysqld: %s", err)
+		return
 	}
 	defer mysqld.Stop()
 
@@ -24,11 +25,13 @@ func TestBasic(t *testing.T) {
 
 	if dsn != wantdsn {
 		t.Errorf("DSN does not match expected (got '%s', want '%s')", dsn, wantdsn)
+		return
 	}
 
 	_, err = sql.Open("mysql", dsn)
 	if err != nil {
 		t.Errorf("Failed to connect to database: %s", err)
+		return
 	}
 
 	// Got to wait for a bit till the log gets anything in it
@@ -37,9 +40,11 @@ func TestBasic(t *testing.T) {
 	buf, err := mysqld.ReadLog()
 	if err != nil {
 		t.Errorf("Failed to read log: %s", err)
+		return
 	}
 	if strings.Index(string(buf), "ready for connections") < 0 {
 		t.Errorf("Could not find 'ready for connections' in log: %s", buf)
+		return
 	}
 
 }
@@ -51,17 +56,20 @@ func TestCopyDataFrom(t *testing.T) {
 	mysqld, err := NewMysqld(config)
 	if err != nil {
 		t.Errorf("Failed to start mysqld: %s", err)
+		return
 	}
 	defer mysqld.Stop()
 
 	db, err := sql.Open("mysql", mysqld.Datasource("test", "", "", 0))
 	if err != nil {
 		t.Errorf("Failed to connect to database: %s", err)
+		return
 	}
 
 	rows, err := db.Query("select id,str from test.hello order by id")
 	if err != nil {
 		t.Errorf("Failed to fetch data: %s", err)
+		return
 	}
 
 	var id int
@@ -71,11 +79,13 @@ func TestCopyDataFrom(t *testing.T) {
 	rows.Scan(&id, &str)
 	if id != 1 || str != "hello" {
 		t.Errorf("Data do not match, got (id:%d str:%s)", id, str)
+		return
 	}
 
 	rows.Next()
 	rows.Scan(&id, &str)
 	if id != 2 || str != "ciao" {
 		t.Errorf("Data do not match, got (id:%d str:%s)", id, str)
+		return
 	}
 }


### PR DESCRIPTION
closes #6 

### 1. The race
The race condition found by `go test -v -race` was caused by the fact that we were running `cmd.Run()` in a separate goroutine while we check for the mysql process via `cmd.Process`

This has been fixed by the suggested fix in https://github.com/lestrrat/go-test/mysqld/pull/6/commits/c1a2eda32d9d3a6e19d47114529faf1315f735cd
    
### 2. The not-so-go-ish
However, we also notice in that above commit we have a busy loop. This is caused by the fact that the original code was built around using busy loops, which is not go-ish at all.

This has been addressed by making sure to use time.Timer and time.Ticker along with select

### 3. The errors
And while we are at it, switched to using github.com/pkg/errors