### PR TITLE
Add DatasourceOption to allow passing optional arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,14 @@ config.Port = 13306
 // Starts mysqld listening on port 13306
 mysqld, _ := mysqltest.NewMysqld(config)
 ```
+
+Certain optional datasource name parameters can be passed:
+
+| Go option | DNS parameter |
+|:----------|:--------------|
+| mysqltest.WithParseTime(bool) | parseTime=[true/false] |
+
+```go
+dsn := mysqld.Datasource("mysql", "root", "", 0, mysqltest.WithParseTime(true))
+// dsn contains "parseTime=true"
+```

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,34 @@
+package mysqltest
+
+import "os/exec"
+
+type DatasourceOption interface {
+	Name() string
+	Value() interface{}
+}
+
+// MysqldConfig is used to configure the new mysql instance
+type MysqldConfig struct {
+	BaseDir        string
+	BindAddress    string
+	CopyDataFrom   string
+	DataDir        string
+	PidFile        string
+	Port           int
+	SkipNetworking bool
+	Socket         string
+	TmpDir         string
+
+	AutoStart      int
+	MysqlInstallDb string
+	Mysqld         string
+}
+
+// TestMysqld is the main struct that handles the execution of mysqld
+type TestMysqld struct {
+	Config       *MysqldConfig
+	Command      *exec.Cmd
+	DefaultsFile string
+	Guards       []func()
+	LogFile      string
+}

--- a/mysqltest_test.go
+++ b/mysqltest_test.go
@@ -3,11 +3,24 @@ package mysqltest
 import (
 	"database/sql"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
 	"strings"
 	"testing"
 	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/assert"
 )
+
+func TestOptions(t *testing.T) {
+	mysqld, err := NewMysqld(NewConfig())
+	if !assert.NoError(t, err, "NewMysqld should succeed") {
+		return
+	}
+	dsn := mysqld.Datasource("mysql", "root", "localhost", 0, WithParseTime(true))
+	if !assert.Regexp(t, "parseTime=true", dsn, "dsn matches expected") {
+		return
+	}
+}
 
 func TestBasic(t *testing.T) {
 	mysqld, err := NewMysqld(NewConfig())

--- a/option.go
+++ b/option.go
@@ -1,0 +1,18 @@
+package mysqltest
+
+type optionWithValue struct {
+	name string
+	value interface {}
+}
+
+func (o *optionWithValue) Name() string {
+	return o.name
+}
+
+func (o *optionWithValue) Value() interface{} {
+	return o.value
+}
+
+func WithParseTime(t bool) DatasourceOption {
+	return &optionWithValue{name: "parseTime", value: t}
+}


### PR DESCRIPTION
Inspired by https://github.com/srmor/go-test-mysqld/commit/54d4e705f542573e1ab24fda0d9f20848a0643d6

But I'm sure we're going to have more of these, so used an Option pattern here.