### PR TITLE
Don't default dbname to "test"

### DIFF
--- a/mysqltest.go
+++ b/mysqltest.go
@@ -420,10 +420,6 @@ func (m *TestMysqld) Datasource(dbname string, user string, pass string, port in
 		user = "root"
 	}
 
-	if dbname == "" {
-		dbname = "test"
-	}
-
 	s := fmt.Sprintf(
 		"%s:%s@%s/%s",
 		user,


### PR DESCRIPTION
It should be possible to connect to MySQL without specifying a DB. This makes that possible by allowing you to specify a db name that is an empty string and no DB will be specified in the DSN.