### PR TITLE
Add method to create a DSN without defaults

### DIFF
--- a/mysqltest.go
+++ b/mysqltest.go
@@ -408,21 +408,8 @@ func (m *TestMysqld) ConnectString(port int) string {
 	return address
 }
 
-// Datasource creates the appropriate Datasource string that can be passed
-// to sql.Open()
-//    mysqld.Datasource("test", "user", "pass", 0)
-//    mysqld.Datasource("test", "user", "pass", 3306)
-func (m *TestMysqld) Datasource(dbname string, user string, pass string, port int, options ...DatasourceOption) string {
-
+func (m *TestMysqld) dsn(dbname string, user string, pass string, port int, options []DatasourceOption) string {
 	address := m.ConnectString(port)
-
-	if user == "" {
-		user = "root"
-	}
-
-	if dbname == "" {
-		dbname = "test"
-	}
 
 	s := fmt.Sprintf(
 		"%s:%s@%s/%s",
@@ -444,7 +431,27 @@ func (m *TestMysqld) Datasource(dbname string, user string, pass string, port in
 		s = s + "?" + qs
 	}
 	return s
+}
 
+// DatasourceWithoutDefaults creates the appropriate Datasource string without any defaults
+func (m *TestMysqld) DatasourceWithoutDefaults(dbname string, user string, pass string, port int, options ...DatasourceOption) string {
+	return m.dsn(dbname, user, pass, port, options)
+}
+
+// Datasource creates the appropriate Datasource string that can be passed
+// to sql.Open()
+//    mysqld.Datasource("test", "user", "pass", 0)
+//    mysqld.Datasource("test", "user", "pass", 3306)
+func (m *TestMysqld) Datasource(dbname string, user string, pass string, port int, options ...DatasourceOption) string {
+	if user == "" {
+		user = "root"
+	}
+
+	if dbname == "" {
+		dbname = "test"
+	}
+
+	return m.dsn(dbname, user, pass, port, options)
 }
 
 // Stop explicitly stops the execution of mysqld

--- a/mysqltest_test.go
+++ b/mysqltest_test.go
@@ -3,6 +3,7 @@ package mysqltest
 import (
 	"database/sql"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"

--- a/mysqltest_test.go
+++ b/mysqltest_test.go
@@ -102,3 +102,39 @@ func TestCopyDataFrom(t *testing.T) {
 		return
 	}
 }
+
+func TestDatasourceWithoutDefaults(t *testing.T) {
+	mysqld, err := NewMysqld(nil)
+	if err != nil {
+		t.Errorf("Failed to start mysqld: %s", err)
+		return
+	}
+	defer mysqld.Stop()
+
+	dsn := mysqld.DatasourceWithoutDefaults("", "", "", 0)
+
+	re := ":@unix\\(/.*mysql\\.sock\\)/"
+	match, _ := regexp.MatchString(re, dsn)
+
+	if !match {
+		t.Errorf("DSN %s should match %s", dsn, re)
+	}
+}
+
+func TestDatasource(t *testing.T) {
+	mysqld, err := NewMysqld(nil)
+	if err != nil {
+		t.Errorf("Failed to start mysqld: %s", err)
+		return
+	}
+	defer mysqld.Stop()
+
+	dsn := mysqld.Datasource("", "", "", 0)
+
+	re := "root:@unix\\(/.*mysql\\.sock\\)/test"
+	match, _ := regexp.MatchString(re, dsn)
+
+	if !match {
+		t.Errorf("DSN %s should match %s", dsn, re)
+	}
+}


### PR DESCRIPTION
Creates a method that allows one to make a DSN without any defaults set. Back compatible since it's a new method that shares the DSN creation code with the Datasource method.